### PR TITLE
Remove link to word list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,1 @@
 Nulac, a word game
-
-
-
-Word list from http://www.becomeawordgameexpert.com/dictionary.htm


### PR DESCRIPTION
Seems like the domain has been bought or something, link redirects to random commercial.